### PR TITLE
Add basic Products API

### DIFF
--- a/ProductosApi/Controllers/ProductosController.cs
+++ b/ProductosApi/Controllers/ProductosController.cs
@@ -1,0 +1,38 @@
+using Dapper;
+using Microsoft.AspNetCore.Mvc;
+using System.Data;
+using ProductosApi.Models;
+
+namespace ProductosApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ProductosController : ControllerBase
+    {
+        private readonly IDbConnection _connection;
+
+        public ProductosController(IDbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        // GET api/productos
+        [HttpGet]
+        public async Task<IEnumerable<Producto>> Get()
+        {
+            var sql = "SELECT Id, Nombre, Precio FROM Productos";
+            var productos = await _connection.QueryAsync<Producto>(sql);
+            return productos;
+        }
+
+        // POST api/productos
+        [HttpPost]
+        public async Task<IActionResult> Post([FromBody] Producto producto)
+        {
+            var sql = "INSERT INTO Productos (Nombre, Precio) VALUES (@Nombre, @Precio); SELECT CAST(SCOPE_IDENTITY() as int);";
+            var id = await _connection.ExecuteScalarAsync<int>(sql, producto);
+            producto.Id = id;
+            return CreatedAtAction(nameof(Get), new { id = producto.Id }, producto);
+        }
+    }
+}

--- a/ProductosApi/Models/Producto.cs
+++ b/ProductosApi/Models/Producto.cs
@@ -1,0 +1,9 @@
+namespace ProductosApi.Models
+{
+    public class Producto
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; } = string.Empty;
+        public decimal Precio { get; set; }
+    }
+}

--- a/ProductosApi/ProductosApi.csproj
+++ b/ProductosApi/ProductosApi.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+</Project>

--- a/ProductosApi/Program.cs
+++ b/ProductosApi/Program.cs
@@ -1,0 +1,30 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// Register IDbConnection for Dapper
+builder.Services.AddTransient<IDbConnection>(_ =>
+    new SqlConnection(builder.Configuration.GetConnectionString("Default")));
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/ProductosApi/Properties/launchSettings.json
+++ b/ProductosApi/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:39844",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "ProductosApi": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5172",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ProductosApi/appsettings.Development.json
+++ b/ProductosApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ProductosApi/appsettings.json
+++ b/ProductosApi/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\mssqllocaldb;Database=ProductosDb;Trusted_Connection=True;"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # azure-backend-net
-API RESTful en .NET 6
+
+Ejemplo de API RESTful en **.NET 6** para gestionar un recurso `Producto`.
+
+## Endpoints
+
+- `GET /api/productos` Obtiene la lista de productos desde SQL Server usando **Dapper**.
+- `POST /api/productos` Crea un nuevo producto.
+
+La cadena de conexión se define en `appsettings.json`.


### PR DESCRIPTION
## Summary
- bootstrap a new .NET 6 Web API project
- define `Producto` model and controller
- configure Dapper with SQL Server connection
- document the new endpoints in the README

## Testing
- `dotnet build ProductosApi/ProductosApi.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6843611846488324b10940ea5e012f52